### PR TITLE
Allow environment variables to be used in settings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 - Initial release
 
-## 1.1.0 - 2020-01-24
+## 1.1.1 - 2020-01-24
 ### Added
 - Ability to use twig strings in the filename config and load arbitrary filenames
+
+## 1.2 - 2020-02-19
+### Added
+- Ability to reference environment variables in the settings pane

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Configuration is supported in the Craft admin panel.
 
 Snapshot filename can contain Twig expressions: `db_snapshot_{{now|date("Ymd-His")}}.sql`
 
+All fields support Craft environment variable references (For example, setting Access Key to `$ACCESS_KEY`)
+
 Be aware that if you use a timestamp in the filename, you will need to provide a filename when using the load action.
 
 ## Using DB Snapshot

--- a/src/console/controllers/SnapshotController.php
+++ b/src/console/controllers/SnapshotController.php
@@ -67,13 +67,13 @@ class SnapshotController extends Controller
 
         $tmpPath = $this->createTempFolder();
 
-        $filename = $view->renderString($settings->filename);
+        $filename = $view->renderString($settings->getFilename());
         $tmpFile = "$tmpPath/$filename";
         $volumeFile = $filename;
 
         try {
             $db->backupTo($tmpFile);
-            if ($settings->compress) {
+            if ($settings->getCompress()) {
                 $compressCmd = "/bin/gzip $tmpFile";
                 shell_exec($compressCmd);
                 $tmpFile = "$tmpFile.gz";
@@ -105,7 +105,7 @@ class SnapshotController extends Controller
         $tmpPath = $this->createTempFolder();
 
         if (!$filename = $this->filename) {
-            $filename = $view->renderString($settings->filename);
+            $filename = $view->renderString($settings->getFilename());
         }
 
         $tmpFile = "$tmpPath/$filename";
@@ -114,7 +114,7 @@ class SnapshotController extends Controller
         try {
             $filesystem = $this->getFilesystem();
 
-            if ($settings->compress) {
+            if ($settings->getCompress()) {
                 $volumeFile = "$volumeFile.gz";
                 $tmpFile = "$tmpFile.gz";
             }
@@ -125,7 +125,7 @@ class SnapshotController extends Controller
                 throw new \RuntimeException("Snapshot $volumeFile does not exist");
             }
 
-            if ($settings->compress) {
+            if ($settings->getCompress()) {
                 $compressCmd = "/bin/gunzip $tmpFile";
                 shell_exec($compressCmd);
                 $tmpFile = str_replace(".gz", "", $tmpFile);
@@ -161,17 +161,17 @@ class SnapshotController extends Controller
         $settings = DbSnapshot::getInstance()->settings;
         $s3Options = [
             'credentials' => [
-                'key' => $settings->accessKey,
-                'secret' => $settings->secretKey
+                'key' => $settings->getAccessKey(),
+                'secret' => $settings->getSecretKey()
             ],
-            'region' => $settings->region,
+            'region' => $settings->getRegion(),
             'version' => 'latest'
         ];
-        if ($settings->endpoint) {
-            $s3Options['endpoint'] = $settings->endpoint;
+        if ($settings->getEndpoint()) {
+            $s3Options['endpoint'] = $settings->getEndpoint();
         }
         $s3Client = new S3Client($s3Options);
-        $s3Adapter = new AwsS3Adapter($s3Client, $settings->bucket, $settings->path);
+        $s3Adapter = new AwsS3Adapter($s3Client, $settings->getBucket(), $settings->getPath());
         $filesystem = new Filesystem($s3Adapter);
         return $filesystem;
     }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -31,6 +31,13 @@ use craft\base\Model;
  */
 class Settings extends Model
 {
+    /**
+     * @return mixed
+     */
+    public function getBucket()
+    {
+        return $this->bucket;
+    }
     public $path = 'db_snapshots';
     public $filename;
     public $compress = true;
@@ -49,6 +56,61 @@ class Settings extends Model
         }
     }
 
+    /**
+     * @return string
+     */
+    public function getPath()
+    {
+        return Craft::parseEnv($this->path);
+    }
+
+    /**
+     * @return string
+     */
+    public function getFilename()
+    {
+        return Craft::parseEnv($this->filename);
+    }
+
+    /**
+     * @return bool
+     */
+    public function getCompress()
+    {
+        return Craft::parseEnv($this->compress);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getAccessKey()
+    {
+        return Craft::parseEnv($this->accessKey);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getSecretKey()
+    {
+        return Craft::parseEnv($this->secretKey);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getEndpoint()
+    {
+        return Craft::parseEnv($this->endpoint);
+    }
+
+    /**
+     * @return string
+     */
+    public function getRegion()
+    {
+        return Craft::parseEnv($this->region);
+    }
 
 
 


### PR DESCRIPTION
Please allow environment variables to be used in the settings so that the credentials can be kept out of the database and in the .env file.

Similar to how the AWS S3 plugin works. https://github.com/craftcms/aws-s3

And please use Crafts parseEnv command so that when set to an empty string it will use the IAM permission on the server. https://github.com/craftcms/aws-s3/issues/49